### PR TITLE
chore: replace uws service name with core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   proxy:
     image: nginx:latest
     depends_on:
-      - uws
+      - core
     ports:
       - ${PROXY_PORT:-9000}:8080
     volumes:
@@ -81,8 +81,8 @@ services:
       timeout: 10s
       retries: 5
 
-  uws:
-    image: relaybox/uws:2.6.0
+  core:
+    image: relaybox/core:2.6.2
     depends_on:
       cache:
         condition: service_healthy
@@ -99,7 +99,7 @@ services:
       - platform_network
 
   auth:
-    image: relaybox/auth:3.8.2
+    image: relaybox/auth:3.9.0
     depends_on:
       db:
         condition: service_healthy

--- a/services/proxy/nginx.conf
+++ b/services/proxy/nginx.conf
@@ -1,8 +1,8 @@
 events {}
 
 http {
-  upstream uws_service {
-    server uws:4004;
+  upstream core_service {
+    server core:4004;
   }
 
   upstream auth_service {
@@ -17,9 +17,9 @@ http {
   server {
     listen 8080;
     
-    # Proxy pass and upgrade requests to /uws (no trailing slash)
-    location /uws {
-      proxy_pass http://uws_service/;
+    # Proxy pass and upgrade requests to /core (no trailing slash)
+    location /core {
+      proxy_pass http://core_service/;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
@@ -27,8 +27,8 @@ http {
     }
 
     # Standard proxt pass for routed requests (http endpoints)
-    location /uws/ {
-      proxy_pass http://uws_service/;
+    location /core/ {
+      proxy_pass http://core_service/;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
     }


### PR DESCRIPTION
Replace `uws` with `core` to reflect repo name change