### PR TITLE
chore: bump image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       retries: 5
 
   core:
-    image: relaybox/core:2.7.2
+    image: relaybox/core:2.8.0
     depends_on:
       cache:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
       - platform_network
 
   webhook:
-    image: relaybox/webhook:1.0.4
+    image: relaybox/webhook:1.0.6
     depends_on:
       cache:
         condition: service_healthy


### PR DESCRIPTION
- core - 2.8.0
- webhook - 1.0.6