### PR TITLE
chore: bump core and history versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       retries: 5
 
   core:
-    image: relaybox/core:2.11.0
+    image: relaybox/core:2.12.0
     depends_on:
       cache:
         condition: service_healthy
@@ -167,7 +167,7 @@ services:
       - platform_network
 
   history:
-    image: relaybox/history:2.3.1
+    image: relaybox/history:2.3.3
     depends_on:
       cache:
         condition: service_healthy


### PR DESCRIPTION
- core 2.11.0 -> 2.12.0
- history 2.3.1 -> 2.3.3